### PR TITLE
Loosely type object util args

### DIFF
--- a/.changeset/chatty-fishes-own.md
+++ b/.changeset/chatty-fishes-own.md
@@ -1,0 +1,10 @@
+---
+'emery': patch
+---
+
+Loosely type object util args.
+
+If folks had strongly typed objects, they wouldn't need these utils. Support any object to save some headaches. Affects:
+
+- `typedEntries()`
+- `typedKeys()`

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -7,7 +7,7 @@ import { ObjectEntry } from '../types';
  * Object.entries({ foo: 1, bar: 2 }) // [string, number][]
  * typedEntries({ foo: 1, bar: 2 }) // ["foo" | "bar", number][]
  */
-export function typedEntries<T extends Record<string, unknown>>(value: T) {
+export function typedEntries<T extends object>(value: T) {
   return Object.entries(value) as ObjectEntry<T>[];
 }
 
@@ -18,6 +18,6 @@ export function typedEntries<T extends Record<string, unknown>>(value: T) {
  * Object.keys({ foo: 1, bar: 2 }) // string[]
  * typedKeys({ foo: 1, bar: 2 }) // ("foo" | "bar")[]
  */
-export function typedKeys<T extends Record<string, unknown>>(value: T): Array<keyof T> {
-  return Object.keys(value);
+export function typedKeys<T extends object>(value: T) {
+  return Object.keys(value) as Array<keyof T>;
 }


### PR DESCRIPTION
If folks had strongly typed objects, they wouldn't need these utils. Support any object to save some headaches.

Affects:
- `typedEntries()`
- `typedKeys()`