### PR TITLE
Assertions: optional debugger

### DIFF
--- a/.changeset/shiny-flowers-fold.md
+++ b/.changeset/shiny-flowers-fold.md
@@ -1,0 +1,5 @@
+---
+'emery': minor
+---
+
+Assertions: support opt-out of debugger

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -9,9 +9,13 @@
 // intentional design decision. The goal is to promote consideration from
 // consumers when dealing with potentially ambiguous conditions like `0` or
 // `''`, which can introduce "subtle" bugs.
-export function assert(condition: boolean, message = 'Assert failed'): asserts condition {
+export function assert(
+  condition: boolean,
+  message = 'Assert failed',
+  options = { debug: true },
+): asserts condition {
   if (!condition) {
-    developmentDebugger();
+    developmentDebugger(options.debug);
     throw new TypeError(message);
   }
 }
@@ -22,14 +26,14 @@ export function assert(condition: boolean, message = 'Assert failed'): asserts c
  * @throws always
  * @returns void
  */
-export function assertNever(condition: never): never {
-  developmentDebugger();
+export function assertNever(condition: never, options = { debug: true }): never {
+  developmentDebugger(options.debug);
   throw new Error(`Unexpected call to assertNever: '${condition}'`);
 }
 
 /** Pause execution in development to aid debugging. */
-function developmentDebugger() {
-  if (process.env.NODE_ENV === 'production') {
+function developmentDebugger(enabled?: boolean): void {
+  if (!enabled || process.env.NODE_ENV === 'production') {
     return;
   }
 


### PR DESCRIPTION
Resolves #32

Allow consumers to opt-out of debugger behaviour within assertions:
- `assert()`
- `assertNever()`