### PR TITLE
Handle readonly arrays for `isNonEmptyArray` guard.

### DIFF
--- a/.changeset/olive-dryers-destroy.md
+++ b/.changeset/olive-dryers-destroy.md
@@ -1,0 +1,5 @@
+---
+'emery': patch
+---
+
+Handle readonly arrays for `isNonEmptyArray` guard.

--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -65,7 +65,9 @@ describe('guards', () => {
   describe('array', () => {
     it('isNonEmptyArray should validate assumed values', () => {
       expect(isNonEmptyArray([1, 2])).toBe(true);
+      expect(isNonEmptyArray([1, 2] as const)).toBe(true);
       expect(isNonEmptyArray([])).toBe(false);
+      expect(isNonEmptyArray([] as const)).toBe(false);
     });
   });
 

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -33,7 +33,7 @@ export function isUndefined(value: unknown): value is undefined {
 // ------------------------------
 
 /** Checks whether or not an array is empty. */
-export function isNonEmptyArray<T>(value: T[]): value is [T, ...T[]] {
+export function isNonEmptyArray<T>(value: readonly T[]): value is [T, ...T[]] {
   return value.length > 0;
 }
 


### PR DESCRIPTION
Small fix to let the `isNonEmptyArray` guard work with readonly arrays due to a type error ([see TS Playground link here](https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABDAzgOQQUQLYAcoCeAggE4kCGBAPACoB8AFAG7kA2IApgFyIkfkATBKwKIaAbQC6ASh4t2HZCkTiaAGkQA6bRMmTEAbwBQiXhyggSSeZ02sOYAOZQAFojqIADAG4jAXyMjCAQUKEQOPEJSClEAXhV9cmVyMAIpX1QMMBx8YjJKBgjc6MppX0JcRRyo-LjECo44YHDIvJjfIJCwosIAJX4hMBESuqlEJMRgsFCM9CxWkcLW-sFhNtLygkrEaoIVweHaxHiGppbc-bWRjqnQs0cQVnISEeOVACIYd413l3ImDjfRDvGwcFDvSSzLK7RZ8B5PF61MpGBqIfrw56vE5bRrNOGPTG1G5dMyrIZ7DgYxExN7iT5A37-QE-UHgxLKW5QKHzYq1Bh8MkidEE6kbFE4tEDNbChFY+o4s4Cg4UqnXIxAA)).