### PR TITLE
Add shields.io badges and footer

### DIFF
--- a/.github/assets/banner.svg
+++ b/.github/assets/banner.svg
@@ -1,0 +1,91 @@
+<svg fill="none" viewBox="0 0 830 265" xmlns="http://www.w3.org/2000/svg">
+  <foreignObject width="100%" height="100%">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <style>
+        .container {
+          font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica,
+            Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+          display: flex;
+          flex-direction: column;
+          height: 265px;
+          width: 100%;
+          margin: 0;
+          background: #111827;
+          border-radius: 12px;
+          color: white;
+          justify-content: space-between;
+          position: absolute;
+        }
+
+        h1 {
+          font-size: 52px;
+          line-height: 1;
+          margin: 0;
+          font-weight: 600;
+          letter-spacing: 1px;
+        }
+
+        p {
+          margin: 0;
+        }
+        
+        .top {
+          margin-top: 40px;
+          margin-left: 40px;
+        }
+        
+        .bottom {
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 40px;
+          margin-left: 40px;
+          margin-right: 40px;
+        }
+        
+        .tagline {
+          margin-top: 16px;
+          color: #b8babe;
+          font-weight: 300;
+          font-size: 17px;
+        }
+        
+        .emoji {
+          font-size: 80px;
+        }
+        
+      </style>
+      <div class="container">
+        <div class="top">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="102"
+            height="32"
+            fill="none"
+          >
+            <title>Thinkmill</title>
+            <path
+              fill="#ED0000"
+              fill-rule="evenodd"
+              d="M15.95 31.95c8.81 0 15.95-7.16 15.95-15.98a15.96 15.96 0 1 0-15.95 15.98Z"
+              clip-rule="evenodd" /><path
+              fill="#fff"
+              fill-rule="evenodd"
+              d="M10.93 17.99c0 .77.25 1.08.93 1.08.18 0 .37-.03.47-.07v1.2c-.23.08-.58.13-.86.13-1.45 0-2.08-.6-2.08-2.11v-3.67H8.24v-1.18h1.15v-1.71h1.54v1.71h1.34v1.18h-1.34V18Zm8.19-3.53a2.42 2.42 0 0 1 2.2-1.25c1.46 0 2.35.95 2.35 2.8v4.24h-1.54v-4.09c0-1.22-.47-1.7-1.24-1.7-.9 0-1.45.77-1.45 2.08v3.7H17.9V16c0-.97-.43-1.54-1.23-1.54-.92 0-1.44.78-1.44 2.1v3.69h-1.54v-6.88h1.47v.83h.03c.48-.66 1.1-.99 1.9-.99.95 0 1.68.44 2.03 1.25ZM48.6 12.08v-1.6h-9.05v1.6h3.6v9.39H45v-9.39h3.61Zm2.88 2.47v-4.07h-1.76v10.99h1.76v-4.35c0-1.5.79-2.26 1.79-2.26.99 0 1.59.56 1.59 1.96v4.65h1.76v-4.8c0-2.15-1.08-3.23-2.86-3.23-.88 0-1.7.36-2.25 1.11h-.03Zm8.9-2.39v-1.68h-1.75v1.68h1.76Zm0 9.3v-7.83h-1.75v7.84h1.76Zm6.14-8.02a2.8 2.8 0 0 0-2.34 1.2h-.03v-1.01h-1.67v7.84h1.76v-4.35c0-1.5.79-2.26 1.79-2.26.99 0 1.59.56 1.59 1.96v4.65h1.76v-4.8c0-2.15-1.08-3.23-2.86-3.23Zm11.93 8.03-3.6-4.26 3.23-3.58h-2.05l-2.85 3.2h-.03v-6.35h-1.76v10.99h1.76v-3.8h.03l3.05 3.8h2.22Zm9.39-8.03c-1.19 0-1.94.53-2.51 1.42-.4-.92-1.24-1.42-2.32-1.42-.92 0-1.62.37-2.17 1.13h-.03v-.94h-1.68v7.84h1.76v-4.2c0-1.51.6-2.4 1.65-2.4.9 0 1.4.64 1.4 1.75v4.85h1.76v-4.23c0-1.5.61-2.38 1.64-2.38.88 0 1.42.56 1.42 1.95v4.66h1.76v-4.83c0-2.12-1.02-3.2-2.68-3.2Zm6.46-1.28v-1.68h-1.76v1.68h1.76Zm0 9.3v-7.83h-1.76v7.84h1.76Zm3.85 0V10.49h-1.76v10.99h1.76Zm3.85 0V10.49h-1.76v10.99H102Z"
+              clip-rule="evenodd"
+          /></svg>
+        </div>
+        <div class="bottom">
+          <div class="left">
+            <h1>Emery</h1>
+            <p class="tagline">Polish for the rough parts of TypeScript</p>
+          </div>
+          <div class="right">
+            <p class="emoji">💎</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </foreignObject>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # Emery
 
+<a href="https://emery-ts.vercel.app/">
+  <img src=".github/assets/banner.svg" alt="Polish for the rough parts of TypeScript">
+  </br>
+  <br><br>
+  </br>
+  <p><b>Polish for the rough parts of TypeScript</b></p>
+</a>
 <p>
   <a aria-label="NPM version" href="https://www.npmjs.com/package/emery.svg">
     <img alt="" src="https://img.shields.io/npm/v/emery.svg?style=for-the-badge&labelColor=0869B8">
   </a>
   <a aria-label="License" href="#">
     <img alt="" src="https://img.shields.io/npm/l/emery.svg?style=for-the-badge&labelColor=579805">
+  </a>
+  <a aria-label="Website" href="https://emery-ts.vercel.app/">
+    <img src="https://img.shields.io/badge/Website-2F6BFF.svg?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBjbGFzcz0iZmVhdGhlciBmZWF0aGVyLWdsb2JlIj48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCI+PC9jaXJjbGU+PGxpbmUgeDE9IjIiIHkxPSIxMiIgeDI9IjIyIiB5Mj0iMTIiPjwvbGluZT48cGF0aCBkPSJNMTIgMmExNS4zIDE1LjMgMCAwIDEgNCAxMCAxNS4zIDE1LjMgMCAwIDEtNCAxMCAxNS4zIDE1LjMgMCAwIDEtNC0xMCAxNS4zIDE1LjMgMCAwIDEgNC0xMHoiPjwvcGF0aD48L3N2Zz4=&labelColor=0737ad&locoColor=white&logoWidth=0">
   </a>
   <a aria-label="Thinkmill Logo" href="https://www.thinkmill.com.au/open-source?utm_campaign=github-emery">
     <img src="https://img.shields.io/badge/A%20Thinkmill%20Project-ed0000.svg?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTg2IiBoZWlnaHQ9IjU4NiIgdmlld0JveD0iMCAwIDU4NiA1ODYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMF8xOTk2XzQwNikiPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTU4NiAyOTNDNTg2IDQ1NC44MTkgNDU0LjgxOSA1ODYgMjkzIDU4NkMxMzEuMTgxIDU4NiAwIDQ1NC44MTkgMCAyOTNDMCAxMzEuMTgxIDEzMS4xODEgMCAyOTMgMEM0NTQuODE5IDAgNTg2IDEzMS4xODEgNTg2IDI5M1pNMjA1Ljc3NiAzNTguOTQ0QzE5MS4zNzYgMzU4Ljk0NCAxODUuOTA0IDM1Mi4zMiAxODUuOTA0IDMzNS45MDRWMjYyLjc1MkgyMTQuNDE2VjIzNy42OTZIMTg1LjkwNFYyMDEuMTJIMTUzLjA3MlYyMzcuNjk2SDEyOC41OTJWMjYyLjc1MkgxNTMuMDcyVjM0MC44QzE1My4wNzIgMzcyLjc2OCAxNjYuNjA4IDM4NS43MjggMTk3LjQyNCAzODUuNzI4QzIwMy40NzIgMzg1LjcyOCAyMTAuOTYgMzg0LjU3NiAyMTUuODU2IDM4My4xMzZWMzU3LjUwNEMyMTMuNTUyIDM1OC4zNjggMjA5LjUyIDM1OC45NDQgMjA1Ljc3NiAzNTguOTQ0Wk00MDcuMzc2IDIzNC4yNEMzODUuMiAyMzQuMjQgMzcxLjA4OCAyNDQuMDMyIDM2MC40MzIgMjYwLjczNkMzNTIuOTQ0IDI0My40NTYgMzM3LjM5MiAyMzQuMjQgMzE3LjIzMiAyMzQuMjRDMjk5Ljk1MiAyMzQuMjQgMjg2Ljk5MiAyNDEuMTUyIDI3Ni42MjQgMjU1LjI2NEgyNzYuMDQ4VjIzNy42OTZIMjQ0LjY1NlYzODRIMjc3LjQ4OFYzMDUuNjY0QzI3Ny40ODggMjc3LjQ0IDI4OC43MiAyNjAuNzM2IDMwOC4zMDQgMjYwLjczNkMzMjUuMjk2IDI2MC43MzYgMzM0LjUxMiAyNzIuODMyIDMzNC41MTIgMjkzLjU2OFYzODRIMzY3LjM0NFYzMDUuMDg4QzM2Ny4zNDQgMjc3LjE1MiAzNzguODY0IDI2MC43MzYgMzk4LjE2IDI2MC43MzZDNDE0LjU3NiAyNjAuNzM2IDQyNC42NTYgMjcxLjEwNCA0MjQuNjU2IDI5Ny4wMjRWMzg0SDQ1Ny40ODhWMjkzLjg1NkM0NTcuNDg4IDI1NC40IDQzOC40OCAyMzQuMjQgNDA3LjM3NiAyMzQuMjRaIiBmaWxsPSJ3aGl0ZSIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzE5OTZfNDA2Ij4KPHJlY3Qgd2lkdGg9IjU4NiIgaGVpZ2h0PSI1ODYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==&labelColor=C60200&locoColor=white&logoWidth=0">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Emery
 
+<p>
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/emery.svg">
+    <img alt="" src="https://img.shields.io/npm/v/emery.svg?style=for-the-badge&labelColor=0869B8">
+  </a>
+  <a aria-label="License" href="#">
+    <img alt="" src="https://img.shields.io/npm/l/emery.svg?style=for-the-badge&labelColor=579805">
+  </a>
+  <a aria-label="Thinkmill Logo" href="https://www.thinkmill.com.au/open-source?utm_campaign=github-emery">
+    <img src="https://img.shields.io/badge/A%20Thinkmill%20Project-ed0000.svg?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTg2IiBoZWlnaHQ9IjU4NiIgdmlld0JveD0iMCAwIDU4NiA1ODYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMF8xOTk2XzQwNikiPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTU4NiAyOTNDNTg2IDQ1NC44MTkgNDU0LjgxOSA1ODYgMjkzIDU4NkMxMzEuMTgxIDU4NiAwIDQ1NC44MTkgMCAyOTNDMCAxMzEuMTgxIDEzMS4xODEgMCAyOTMgMEM0NTQuODE5IDAgNTg2IDEzMS4xODEgNTg2IDI5M1pNMjA1Ljc3NiAzNTguOTQ0QzE5MS4zNzYgMzU4Ljk0NCAxODUuOTA0IDM1Mi4zMiAxODUuOTA0IDMzNS45MDRWMjYyLjc1MkgyMTQuNDE2VjIzNy42OTZIMTg1LjkwNFYyMDEuMTJIMTUzLjA3MlYyMzcuNjk2SDEyOC41OTJWMjYyLjc1MkgxNTMuMDcyVjM0MC44QzE1My4wNzIgMzcyLjc2OCAxNjYuNjA4IDM4NS43MjggMTk3LjQyNCAzODUuNzI4QzIwMy40NzIgMzg1LjcyOCAyMTAuOTYgMzg0LjU3NiAyMTUuODU2IDM4My4xMzZWMzU3LjUwNEMyMTMuNTUyIDM1OC4zNjggMjA5LjUyIDM1OC45NDQgMjA1Ljc3NiAzNTguOTQ0Wk00MDcuMzc2IDIzNC4yNEMzODUuMiAyMzQuMjQgMzcxLjA4OCAyNDQuMDMyIDM2MC40MzIgMjYwLjczNkMzNTIuOTQ0IDI0My40NTYgMzM3LjM5MiAyMzQuMjQgMzE3LjIzMiAyMzQuMjRDMjk5Ljk1MiAyMzQuMjQgMjg2Ljk5MiAyNDEuMTUyIDI3Ni42MjQgMjU1LjI2NEgyNzYuMDQ4VjIzNy42OTZIMjQ0LjY1NlYzODRIMjc3LjQ4OFYzMDUuNjY0QzI3Ny40ODggMjc3LjQ0IDI4OC43MiAyNjAuNzM2IDMwOC4zMDQgMjYwLjczNkMzMjUuMjk2IDI2MC43MzYgMzM0LjUxMiAyNzIuODMyIDMzNC41MTIgMjkzLjU2OFYzODRIMzY3LjM0NFYzMDUuMDg4QzM2Ny4zNDQgMjc3LjE1MiAzNzguODY0IDI2MC43MzYgMzk4LjE2IDI2MC43MzZDNDE0LjU3NiAyNjAuNzM2IDQyNC42NTYgMjcxLjEwNCA0MjQuNjU2IDI5Ny4wMjRWMzg0SDQ1Ny40ODhWMjkzLjg1NkM0NTcuNDg4IDI1NC40IDQzOC40OCAyMzQuMjQgNDA3LjM3NiAyMzQuMjRaIiBmaWxsPSJ3aGl0ZSIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzE5OTZfNDA2Ij4KPHJlY3Qgd2lkdGg9IjU4NiIgaGVpZ2h0PSI1ODYiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==&labelColor=C60200&locoColor=white&logoWidth=0">
+  </a>
+</p>
+
+---
+
 💎 Polish for the rough parts of TypeScript.
 
 TypeScript is great but there's parts that are still rough around the edges, especially for developers who are new to the language.
@@ -65,3 +79,11 @@ const thing2 = typedKeys(obj).map(key => {
 Like all good things, Emery started with curiosity. At [Thinkmill](https://thinkmill.com.au/) we have an internal Slack channel for TypeScript where a question was raised about how to offer consumers error messages that convey intent, not just cascading type failures.
 
 While that's not currently possible, it became apparent that there was demand for a solution. We also discovered that many developers were carrying around miscellaneous utilities for working with TypeScript between projects.
+
+---
+
+## License
+
+Copyright (c) 2023
+[Thinkmill Labs](https://www.thinkmill.com.au/labs?utm_campaign=github-emery)
+Pty Ltd. Licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Emery
 
 <a href="https://emery-ts.vercel.app/">
-  <img src=".github/assets/banner.svg" alt="Polish for the rough parts of TypeScript">
-  </br>
-  <br><br>
-  </br>
-  <p><b>Polish for the rough parts of TypeScript</b></p>
+  <img src=".github/assets/banner.svg" alt="Polish for the rough parts of TypeScript" />
 </a>
 <p>
   <a aria-label="NPM version" href="https://www.npmjs.com/package/emery.svg">


### PR DESCRIPTION
This pull request adds some https://shields.io badges to the README, for the following:
- `npm`
- MIT license
- A project by [Thinkmill](https://www.thinkmill.com.au/)

Additionally it adds a footer to refer to the project license.