### PR TITLE
Added exports field to package.json files

### DIFF
--- a/assertions/package.json
+++ b/assertions/package.json
@@ -9,13 +9,13 @@
         "types": "./dist/emery-assertions.cjs.d.ts",
         "default": "./dist/emery-assertions.esm.js"
       },
-      "default": {
-        "types": "./dist/emery-assertions.cjs.d.ts",
-        "import": "./dist/emery-assertions.esm.js"
-      },
       "require": {
         "types": "./dist/emery-assertions.cjs.d.ts",
-        "import": "./dist/emery-assertions.cjs.js"
+        "default": "./dist/emery-assertions.cjs.js"
+      },
+      "default": {
+        "types": "./dist/emery-assertions.cjs.d.ts",
+        "default": "./dist/emery-assertions.esm.js"
       }
     }
   }

--- a/assertions/package.json
+++ b/assertions/package.json
@@ -1,4 +1,22 @@
 {
+  "type": "module",
+  "types": "dist/emery-assertions.cjs.d.ts",
+  "module": "dist/emery-assertions.esm.js",
   "main": "dist/emery-assertions.cjs.js",
-  "module": "dist/emery-assertions.esm.js"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/emery-assertions.cjs.d.ts",
+        "default": "./dist/emery-assertions.esm.js"
+      },
+      "default": {
+        "types": "./dist/emery-assertions.cjs.d.ts",
+        "import": "./dist/emery-assertions.esm.js"
+      },
+      "require": {
+        "types": "./dist/emery-assertions.cjs.d.ts",
+        "import": "./dist/emery-assertions.cjs.js"
+      }
+    }
+  }
 }

--- a/checks/package.json
+++ b/checks/package.json
@@ -1,4 +1,22 @@
 {
+  "type": "module",
+  "types": "dist/emery-checks.cjs.d.ts",
+  "module": "dist/emery-checks.esm.js",
   "main": "dist/emery-checks.cjs.js",
-  "module": "dist/emery-checks.esm.js"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/emery-checks.cjs.d.ts",
+        "default": "./dist/emery-checks.esm.js"
+      },
+      "default": {
+        "types": "./dist/emery-checks.cjs.d.ts",
+        "import": "./dist/emery-checks.esm.js"
+      },
+      "require": {
+        "types": "./dist/emery-checks.cjs.d.ts",
+        "import": "./dist/emery-checks.cjs.js"
+      }
+    }
+  }
 }

--- a/checks/package.json
+++ b/checks/package.json
@@ -9,13 +9,13 @@
         "types": "./dist/emery-checks.cjs.d.ts",
         "default": "./dist/emery-checks.esm.js"
       },
-      "default": {
-        "types": "./dist/emery-checks.cjs.d.ts",
-        "import": "./dist/emery-checks.esm.js"
-      },
       "require": {
         "types": "./dist/emery-checks.cjs.d.ts",
-        "import": "./dist/emery-checks.cjs.js"
+        "default": "./dist/emery-checks.cjs.js"
+      },
+      "default": {
+        "types": "./dist/emery-checks.cjs.d.ts",
+        "default": "./dist/emery-checks.esm.js"
       }
     }
   }

--- a/guards/package.json
+++ b/guards/package.json
@@ -9,13 +9,13 @@
         "types": "./dist/emery-guards.cjs.d.ts",
         "default": "./dist/emery-guards.esm.js"
       },
-      "default": {
-        "types": "./dist/emery-guards.cjs.d.ts",
-        "import": "./dist/emery-guards.esm.js"
-      },
       "require": {
         "types": "./dist/emery-guards.cjs.d.ts",
-        "import": "./dist/emery-guards.cjs.js"
+        "default": "./dist/emery-guards.cjs.js"
+      },
+      "default": {
+        "types": "./dist/emery-guards.cjs.d.ts",
+        "default": "./dist/emery-guards.esm.js"
       }
     }
   }

--- a/guards/package.json
+++ b/guards/package.json
@@ -1,4 +1,22 @@
 {
+  "type": "module",
+  "types": "dist/emery-guards.cjs.d.ts",
+  "module": "dist/emery-guards.esm.js",
   "main": "dist/emery-guards.cjs.js",
-  "module": "dist/emery-guards.esm.js"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/emery-guards.cjs.d.ts",
+        "default": "./dist/emery-guards.esm.js"
+      },
+      "default": {
+        "types": "./dist/emery-guards.cjs.d.ts",
+        "import": "./dist/emery-guards.esm.js"
+      },
+      "require": {
+        "types": "./dist/emery-guards.cjs.d.ts",
+        "import": "./dist/emery-guards.cjs.js"
+      }
+    }
+  }
 }

--- a/opaques/package.json
+++ b/opaques/package.json
@@ -1,4 +1,22 @@
 {
+  "type": "module",
+  "types": "dist/emery-opaques.cjs.d.ts",
+  "module": "dist/emery-opaques.esm.js",
   "main": "dist/emery-opaques.cjs.js",
-  "module": "dist/emery-opaques.esm.js"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/emery-opaques.cjs.d.ts",
+        "default": "./dist/emery-opaques.esm.js"
+      },
+      "default": {
+        "types": "./dist/emery-opaques.cjs.d.ts",
+        "import": "./dist/emery-opaques.esm.js"
+      },
+      "require": {
+        "types": "./dist/emery-opaques.cjs.d.ts",
+        "import": "./dist/emery-opaques.cjs.js"
+      }
+    }
+  }
 }

--- a/opaques/package.json
+++ b/opaques/package.json
@@ -9,13 +9,13 @@
         "types": "./dist/emery-opaques.cjs.d.ts",
         "default": "./dist/emery-opaques.esm.js"
       },
-      "default": {
-        "types": "./dist/emery-opaques.cjs.d.ts",
-        "import": "./dist/emery-opaques.esm.js"
-      },
       "require": {
         "types": "./dist/emery-opaques.cjs.d.ts",
-        "import": "./dist/emery-opaques.cjs.js"
+        "default": "./dist/emery-opaques.cjs.js"
+      },
+      "default": {
+        "types": "./dist/emery-opaques.cjs.d.ts",
+        "default": "./dist/emery-opaques.esm.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
         "types": "./dist/emery.cjs.d.ts",
         "default": "./dist/emery.esm.js"
       },
-      "default": {
-        "types": "./dist/emery.cjs.d.ts",
-        "import": "./dist/emery.esm.js"
-      },
       "require": {
         "types": "./dist/emery.cjs.d.ts",
-        "import": "./dist/emery.cjs.js"
+        "default": "./dist/emery.cjs.js"
+      },
+      "default": {
+        "types": "./dist/emery.cjs.d.ts",
+        "default": "./dist/emery.esm.js"
       }
     },
     "./guards": {
@@ -26,13 +26,13 @@
         "types": "./guards/dist/emery-guards.cjs.d.ts",
         "default": "./guards/dist/emery-guards.esm.js"
       },
-      "default": {
-        "types": "./guards/dist/emery-guards.cjs.d.ts",
-        "import": "./guards/dist/emery-guards.esm.js"
-      },
       "require": {
         "types": "./guards/dist/emery-guards.cjs.d.ts",
-        "import": "./guards/dist/emery-guards.cjs.js"
+        "default": "./guards/dist/emery-guards.cjs.js"
+      },
+      "default": {
+        "types": "./guards/dist/emery-guards.cjs.d.ts",
+        "default": "./guards/dist/emery-guards.esm.js"
       }
     },
     "./opaques": {
@@ -40,13 +40,13 @@
         "types": "./opaques/dist/emery-opaques.cjs.d.ts",
         "default": "./opaques/dist/emery-opaques.esm.js"
       },
-      "default": {
-        "types": "./opaques/dist/emery-opaques.cjs.d.ts",
-        "import": "./opaques/dist/emery-opaques.esm.js"
-      },
       "require": {
         "types": "./opaques/dist/emery-opaques.cjs.d.ts",
-        "import": "./opaques/dist/emery-opaques.cjs.js"
+        "default": "./opaques/dist/emery-opaques.cjs.js"
+      },
+      "default": {
+        "types": "./opaques/dist/emery-opaques.cjs.d.ts",
+        "default": "./opaques/dist/emery-opaques.esm.js"
       }
     },
     "./assertions": {
@@ -54,13 +54,13 @@
         "types": "./assertions/dist/emery-assertions.cjs.d.ts",
         "default": "./assertions/dist/emery-assertions.esm.js"
       },
-      "default": {
-        "types": "./assertions/dist/emery-assertions.cjs.d.ts",
-        "import": "./assertions/dist/emery-assertions.esm.js"
-      },
       "require": {
         "types": "./assertions/dist/emery-assertions.cjs.d.ts",
-        "import": "./assertions/dist/emery-assertions.cjs.js"
+        "default": "./assertions/dist/emery-assertions.cjs.js"
+      },
+      "default": {
+        "types": "./assertions/dist/emery-assertions.cjs.d.ts",
+        "default": "./assertions/dist/emery-assertions.esm.js"
       }
     },
     "./utils": {
@@ -68,13 +68,13 @@
         "types": "./utils/dist/emery-utils.cjs.d.ts",
         "default": "./utils/dist/emery-utils.esm.js"
       },
-      "default": {
-        "types": "./utils/dist/emery-utils.cjs.d.ts",
-        "import": "./utils/dist/emery-utils.esm.js"
-      },
       "require": {
         "types": "./utils/dist/emery-utils.cjs.d.ts",
-        "import": "./utils/dist/emery-utils.cjs.js"
+        "default": "./utils/dist/emery-utils.cjs.js"
+      },
+      "default": {
+        "types": "./utils/dist/emery-utils.cjs.d.ts",
+        "default": "./utils/dist/emery-utils.esm.js"
       }
     },
     "./checks": {
@@ -82,13 +82,13 @@
         "types": "./checks/dist/emery-checks.cjs.d.ts",
         "default": "./checks/dist/emery-checks.esm.js"
       },
-      "default": {
-        "types": "./checks/dist/emery-checks.cjs.d.ts",
-        "import": "./checks/dist/emery-checks.esm.js"
-      },
       "require": {
         "types": "./checks/dist/emery-checks.cjs.d.ts",
-        "import": "./checks/dist/emery-checks.cjs.js"
+        "default": "./checks/dist/emery-checks.cjs.js"
+      },
+      "default": {
+        "types": "./checks/dist/emery-checks.cjs.d.ts",
+        "default": "./checks/dist/emery-checks.esm.js"
       }
     },
     "./package.json": "./package.json"
@@ -171,5 +171,6 @@
     "typescript": "^4.6.4",
     "@changesets/changelog-github": "^0.4.5",
     "@changesets/cli": "^2.23.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -2,32 +2,94 @@
   "name": "emery",
   "version": "1.4.3",
   "description": "Utilities to help polish the rough parts of TypeScript.",
-  "main": "dist/emery.cjs.js",
+  "type": "module",
+  "types": "dist/emery.cjs.d.ts",
   "module": "dist/emery.esm.js",
+  "main": "dist/emery.cjs.js",
   "exports": {
     ".": {
-      "module": "./dist/emery.esm.js",
-      "default": "./dist/emery.cjs.js"
+      "import": {
+        "types": "./dist/emery.cjs.d.ts",
+        "default": "./dist/emery.esm.js"
+      },
+      "default": {
+        "types": "./dist/emery.cjs.d.ts",
+        "import": "./dist/emery.esm.js"
+      },
+      "require": {
+        "types": "./dist/emery.cjs.d.ts",
+        "import": "./dist/emery.cjs.js"
+      }
     },
     "./guards": {
-      "module": "./guards/dist/emery-guards.esm.js",
-      "default": "./guards/dist/emery-guards.cjs.js"
+      "import": {
+        "types": "./guards/dist/emery-guards.cjs.d.ts",
+        "default": "./guards/dist/emery-guards.esm.js"
+      },
+      "default": {
+        "types": "./guards/dist/emery-guards.cjs.d.ts",
+        "import": "./guards/dist/emery-guards.esm.js"
+      },
+      "require": {
+        "types": "./guards/dist/emery-guards.cjs.d.ts",
+        "import": "./guards/dist/emery-guards.cjs.js"
+      }
     },
     "./opaques": {
-      "module": "./opaques/dist/emery-opaques.esm.js",
-      "default": "./opaques/dist/emery-opaques.cjs.js"
+      "import": {
+        "types": "./opaques/dist/emery-opaques.cjs.d.ts",
+        "default": "./opaques/dist/emery-opaques.esm.js"
+      },
+      "default": {
+        "types": "./opaques/dist/emery-opaques.cjs.d.ts",
+        "import": "./opaques/dist/emery-opaques.esm.js"
+      },
+      "require": {
+        "types": "./opaques/dist/emery-opaques.cjs.d.ts",
+        "import": "./opaques/dist/emery-opaques.cjs.js"
+      }
     },
     "./assertions": {
-      "module": "./assertions/dist/emery-assertions.esm.js",
-      "default": "./assertions/dist/emery-assertions.cjs.js"
+      "import": {
+        "types": "./assertions/dist/emery-assertions.cjs.d.ts",
+        "default": "./assertions/dist/emery-assertions.esm.js"
+      },
+      "default": {
+        "types": "./assertions/dist/emery-assertions.cjs.d.ts",
+        "import": "./assertions/dist/emery-assertions.esm.js"
+      },
+      "require": {
+        "types": "./assertions/dist/emery-assertions.cjs.d.ts",
+        "import": "./assertions/dist/emery-assertions.cjs.js"
+      }
     },
     "./utils": {
-      "module": "./utils/dist/emery-utils.esm.js",
-      "default": "./utils/dist/emery-utils.cjs.js"
+      "import": {
+        "types": "./utils/dist/emery-utils.cjs.d.ts",
+        "default": "./utils/dist/emery-utils.esm.js"
+      },
+      "default": {
+        "types": "./utils/dist/emery-utils.cjs.d.ts",
+        "import": "./utils/dist/emery-utils.esm.js"
+      },
+      "require": {
+        "types": "./utils/dist/emery-utils.cjs.d.ts",
+        "import": "./utils/dist/emery-utils.cjs.js"
+      }
     },
     "./checks": {
-      "module": "./checks/dist/emery-checks.esm.js",
-      "default": "./checks/dist/emery-checks.cjs.js"
+      "import": {
+        "types": "./checks/dist/emery-checks.cjs.d.ts",
+        "default": "./checks/dist/emery-checks.esm.js"
+      },
+      "default": {
+        "types": "./checks/dist/emery-checks.cjs.d.ts",
+        "import": "./checks/dist/emery-checks.esm.js"
+      },
+      "require": {
+        "types": "./checks/dist/emery-checks.cjs.d.ts",
+        "import": "./checks/dist/emery-checks.cjs.js"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/utils/package.json
+++ b/utils/package.json
@@ -9,13 +9,13 @@
         "types": "./dist/emery-utils.cjs.d.ts",
         "default": "./dist/emery-utils.esm.js"
       },
-      "default": {
-        "types": "./dist/emery-utils.cjs.d.ts",
-        "import": "./dist/emery-utils.esm.js"
-      },
       "require": {
         "types": "./dist/emery-utils.cjs.d.ts",
-        "import": "./dist/emery-utils.cjs.js"
+        "default": "./dist/emery-utils.cjs.js"
+      },
+      "default": {
+        "types": "./dist/emery-utils.cjs.d.ts",
+        "default": "./dist/emery-utils.esm.js"
       }
     }
   }

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,4 +1,22 @@
 {
+  "type": "module",
+  "types": "dist/emery-utils.cjs.d.ts",
+  "module": "dist/emery-utils.esm.js",
   "main": "dist/emery-utils.cjs.js",
-  "module": "dist/emery-utils.esm.js"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/emery-utils.cjs.d.ts",
+        "default": "./dist/emery-utils.esm.js"
+      },
+      "default": {
+        "types": "./dist/emery-utils.cjs.d.ts",
+        "import": "./dist/emery-utils.esm.js"
+      },
+      "require": {
+        "types": "./dist/emery-utils.cjs.d.ts",
+        "import": "./dist/emery-utils.cjs.js"
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Added support for [package.json `.exports` field](https://nodejs.org/api/packages.html#conditional-exports)
- Included in the `.exports` field are [`.types` fields for TypeScript](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)
- Kept previous `.main` and `.module` fields for usage in older versions of Node